### PR TITLE
support for multiple ips

### DIFF
--- a/app/models/api_app.rb
+++ b/app/models/api_app.rb
@@ -16,7 +16,11 @@ class ApiApp < ActiveRecord::Base
       return false unless /^161.52\.\d+\.\d+/.match(ip_address)
       app = where(app_token: app_token).first
     else
-      app = where(app_token: app_token, ip_address: ip_address).first
+      app = where(
+        "app_token = ? AND ip_address LIKE ?",
+        app_token,
+        "%#{ip_address}%"
+      ).first
     end
 
     if app.present? && app.authenticate(app_secret)

--- a/spec/models/api_app_spec.rb
+++ b/spec/models/api_app_spec.rb
@@ -64,6 +64,13 @@ describe ApiApp do
     ApiApp.authenticate(a.app_token, a.app_secret, nil)
   end
 
+  it "should be authenticated with correct credentials and ip range" do
+    ips = %w[127.0.0.2 127.0.0.3]
+    a = create(:api_app, ip_address: ips)
+    expect(ApiApp.authenticate(a.app_token, a.app_secret, ips.first)).to be_truthy
+    expect(ApiApp.authenticate(a.app_token, a.app_secret, ips.last)).to be_truthy
+  end
+
   it "should be authenticated with correct credentials" do
     a = create(:api_app)
     ApiApp.authenticate(a.app_token, a.app_secret, a.ip_address)


### PR DESCRIPTION
quick fix to add support for mutliple ips per token. Project will be deprecated so this fix should be good enough. Be aware that the max size for the `ip_address` field is currently 255 characters, but since we only need to add 2 for this workaround this limitation should be fine